### PR TITLE
Support SSL on backend/ability to disable ssl verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Environment variables:
 * `BACKEND` - to requests are proxied to (_mandatory_)
 * `PROXY_HOST` - the hostname the proxy is available - falls back to the host name of the container.
 * `SCHEMA` - the schema via the proxy is available (defaults to `https`) - _Note:_ This is not the protocol how the proxy accepts. SSL termination is not a responsibility of this image.
+* `DISABLE_SSL_VERIFY` - disabled ssl verification, use if the backend SSL certificate is invalid (defaults to false).
 * `REMOTE_USER_EMAIL_SAML_ATTRIBUTE` - the SAML attribute to be sent as `Remote-User-Name header`
 * `REMOTE_USER_NAME_SAML_ATTRIBUTE` - the SAML attribute to be sent as `Remote-User-Email`
 * `REMOTE_USER_PREFERRED_USERNAME_SAML_ATTRIBUTE` - the SAML attribute to be sent as `Remote-User-Preferred-Username`

--- a/configure
+++ b/configure
@@ -98,5 +98,15 @@ export REQUEST_HEADERS
 # configure Apache proxy and auth
 cat /etc/httpd/conf.d/proxy.conf.template | envsubst '$SCHEMA,$HOST,$BACKEND,$MELLON_PATH,$REQUEST_HEADERS' > /etc/httpd/conf.d/proxy.conf
 
+# Support proxy resutsts to SSL backend
+echo "SSLProxyEngine on" >> /etc/httpd/conf.d/ssl.conf
+
+if [ -n "$DISABLE_SSL_VERIFY" ]; then
+  # Ignore SSL certificate validity
+  echo "SSLProxyCheckPeerName off" >> /etc/httpd/conf.d/ssl.conf
+  echo "SSLProxyVerify none" >> /etc/httpd/conf.d/ssl.conf
+  echo "SSLProxyCheckPeerExpire off" >> /etc/httpd/conf.d/ssl.conf
+fi
+
 # Start apache
 httpd -DFOREGROUND


### PR DESCRIPTION
When running the proxy against an SSL backend I was receiving errors as follows:
```
[Mon Aug 04 00:03:26 2014] [error] proxy: HTTPS: failed to enable ssl support for [::1]:9443 (localhost)
[Mon Aug 04 00:03:31 2014] [error] [client ::1] SSL Proxy requested for xxx but not enabled [Hint: SSLProxyEngine]
```
This led to adding the SSLProxyEngine on to the configuration, from my testing this has no bearing if the backend is http

My backend uses a self signed SSL certificate which resulted in the following log messages when running with SSLProxyEngine configured
```
[Tue Sep 10 18:22:52.959291 2013] [proxy:error] [pid 19531] (502)Unknown error 502: [client 173.xx.xx.xx:9558] AH01084: pass request body failed to 184.xx.xx.xx:2096 (184.xx.xx.xx), referer: https://domain.com:2096
```

I added the DISABLE_SSL_VERIFY toggle which effectively disables SSL certificate verification against the backend.  