### PR TITLE
exec httpd so it can receive stop signal

### DIFF
--- a/configure
+++ b/configure
@@ -99,4 +99,4 @@ export REQUEST_HEADERS
 cat /etc/httpd/conf.d/proxy.conf.template | envsubst '$SCHEMA,$HOST,$BACKEND,$MELLON_PATH,$REQUEST_HEADERS' > /etc/httpd/conf.d/proxy.conf
 
 # Start apache
-httpd -DFOREGROUND
+exec httpd -DFOREGROUND


### PR DESCRIPTION
The long-running process in a container needs to be the one that receives the stop signal. This will allow the container to stop gracefully when Docker sends a signal, instead of being killed.